### PR TITLE
Improved connection

### DIFF
--- a/encode_utils/connection.py
+++ b/encode_utils/connection.py
@@ -168,8 +168,13 @@ class Connection():
         raise Exception("You must supply the `dcc_mode` argument or set the environment variable DCC_MODE.")
     dcc_mode = dcc_mode.lower()
     if dcc_mode not in eu.DCC_MODES:
-      raise Exception(
-        "The specified dcc_mode of '{}' is not valid. Should be one of '{}' or '{}'.".format(dcc_mode, eu.DCC_MODES.keys()))
+      #: assume dcc_mode is a valid demo host
+      self.dcc_host = dcc_mode
+      self.dcc_url = 'https://' + dcc_mode + '/'
+      try: 
+        requests.get(self.dcc_url)
+      except Exception as e:
+        "'{}': The specified dcc_mode of '{}' is not valid. Should be one of '{}' or a valid demo.encodedcc.org hostname.".format(e, dcc_mode, eu.DCC_MODES.keys())
     return dcc_mode
 
   def _get_logfile_name(self,tag):

--- a/encode_utils/connection.py
+++ b/encode_utils/connection.py
@@ -157,9 +157,12 @@ class Connection():
     #: to the value of the `DCC_SECRET_KEY` environment variable in the ``_set_api_keys()`` private 
     #: instance method.
     self.secret_key = self._set_api_keys()[1]
-    self.auth = (self.api_key,self.secret_key)
-    if not self.api_key or not self.secret_key:
-      self.log_error("WARNING: API keys not set, all functions have no permission")
+    if self.api_key and self.secret_key:
+      self.auth = (self.api_key,self.secret_key)
+    else:
+      self.auth = ()
+      self.log_error("WARNING: API keys {} not set, all functions have no permission".format(self.auth))
+
 
   def _set_dcc_mode(self,dcc_mode=False):
     if not dcc_mode:
@@ -171,10 +174,12 @@ class Connection():
     dcc_mode = dcc_mode.lower()
     if dcc_mode not in eu.DCC_MODES:
       #: assume dcc_mode is a valid demo host
-      self.dcc_host = dcc_mode
-      self.dcc_url = 'https://' + dcc_mode + '/'
+      eu.DCC_MODES[dcc_mode] = {
+        'host': dcc_mode,
+        'url': 'https://' + dcc_mode + '/'
+      }
       try: 
-        requests.get(self.dcc_url)
+        requests.get(eu.DCC_MODES[dcc_mode]['url'])
       except Exception as e:
         "'{}': The specified dcc_mode of '{}' is not valid. Should be one of '{}' or a valid demo.encodedcc.org hostname.".format(e, dcc_mode, eu.DCC_MODES.keys())
     return dcc_mode

--- a/encode_utils/connection.py
+++ b/encode_utils/connection.py
@@ -158,6 +158,8 @@ class Connection():
     #: instance method.
     self.secret_key = self._set_api_keys()[1]
     self.auth = (self.api_key,self.secret_key)
+    if not self.api_key or not self.secret_key:
+      self.log_error("WARNING: API keys not set, all functions have no permission")
 
   def _set_dcc_mode(self,dcc_mode=False):
     if not dcc_mode:
@@ -204,8 +206,8 @@ class Connection():
     Returns:
         `tuple`: Two item tuple containing the API Key and the Secret Key
     """
-    api_key = os.environ["DCC_API_KEY"]
-    secret_key = os.environ["DCC_SECRET_KEY"]
+    api_key = os.environ.get("DCC_API_KEY")
+    secret_key = os.environ.get("DCC_SECRET_KEY")
     return api_key,secret_key
 
   def _log_post(self,alias,dcc_id):

--- a/encode_utils/tests/test_connection.py
+++ b/encode_utils/tests/test_connection.py
@@ -18,7 +18,11 @@ import encode_utils as eu
 from encode_utils import connection
 from encode_utils import profiles
 
-DATA_DIR = "data"
+#DATA_DIR = "data"
+DATA_DIR_NAME = "data"
+for root, dirs, files in os.walk('.'):
+      if DATA_DIR_NAME in dirs:
+        DATA_DIR = os.path.join(root, DATA_DIR_NAME)
 
 class TestConnection(unittest.TestCase):
   """Tests the ``encode_utils.connection.py`` module.
@@ -27,6 +31,11 @@ class TestConnection(unittest.TestCase):
   def setUp(self):
     self.conn = connection.Connection(eu.DCC_DEV_MODE)
 
+
+  def test_arbitrary_host(self):
+    self.conn = connection.Connection(dcc_mode='test.encodedcc.org')
+
+
   def test_before_file_post(self):
     """
     Tests the method ``before_file_post()`` for correctly setting the `md5sum` property of a 
@@ -34,7 +43,7 @@ class TestConnection(unittest.TestCase):
     """
     payload = {
       self.conn.PROFILE_KEY: profiles.Profile.FILE_PROFILE_ID,
-      profiles.Profile.SUBMITTED_FILE_PROP_NAME: "data/test_fq_40recs.fastq.gz"
+      profiles.Profile.SUBMITTED_FILE_PROP_NAME: DATA_DIR+"/test_fq_40recs.fastq.gz"
     }
     res = self.conn.before_post_file(payload)
     self.assertEquals(res["md5sum"],"a3e7cb3df359d0642ab0edd33ea7e93e")
@@ -164,6 +173,11 @@ class TestConnection(unittest.TestCase):
     res = self.conn.make_search_url(search_args=query,limit=1) 
     query = "search/?assay_title=ChIP-seq&biosample_type=primary+cell&limit=1&organ_slims=blood&type=Experiment"
     self.assertEquals(res,os.path.join(self.conn.dcc_url,query))
+
+  def test_get(self):
+    res = self.conn.get('experiments/ENCSR502NRF/', frame='object')
+    self.assertEquals(res.get('uuid',""), "e44c59cc-f14a-4722-a9c5-2fe63c2b9533")
+
 
 if __name__ == "__main__":
   unittest.main()

--- a/encode_utils/tests/test_connection.py
+++ b/encode_utils/tests/test_connection.py
@@ -31,6 +31,11 @@ class TestConnection(unittest.TestCase):
   def setUp(self):
     self.conn = connection.Connection(eu.DCC_DEV_MODE)
 
+
+  def test_arbitrary_host(self):
+    self.conn = connection.Connection(dcc_mode='test.encodedcc.org')
+
+
   def test_before_file_post(self):
     """
     Tests the method ``before_file_post()`` for correctly setting the `md5sum` property of a 
@@ -168,6 +173,11 @@ class TestConnection(unittest.TestCase):
     res = self.conn.make_search_url(search_args=query,limit=1) 
     query = "search/?assay_title=ChIP-seq&biosample_type=primary+cell&limit=1&organ_slims=blood&type=Experiment"
     self.assertEquals(res,os.path.join(self.conn.dcc_url,query))
+
+  def test_get(self):
+    res = self.conn.get('experiments/ENCSR502NRF/', frame='object')
+    self.assertEquals(res.get('uuid',""), "e44c59cc-f14a-4722-a9c5-2fe63c2b9533")
+
 
 if __name__ == "__main__":
   unittest.main()

--- a/encode_utils/tests/test_connection.py
+++ b/encode_utils/tests/test_connection.py
@@ -18,11 +18,7 @@ import encode_utils as eu
 from encode_utils import connection
 from encode_utils import profiles
 
-#DATA_DIR = "data"
-DATA_DIR_NAME = "data"
-for root, dirs, files in os.walk('.'):
-      if DATA_DIR_NAME in dirs:
-        DATA_DIR = os.path.join(root, DATA_DIR_NAME)
+DATA_DIR = "data"
 
 class TestConnection(unittest.TestCase):
   """Tests the ``encode_utils.connection.py`` module.
@@ -31,11 +27,6 @@ class TestConnection(unittest.TestCase):
   def setUp(self):
     self.conn = connection.Connection(eu.DCC_DEV_MODE)
 
-
-  def test_arbitrary_host(self):
-    self.conn = connection.Connection(dcc_mode='test.encodedcc.org')
-
-
   def test_before_file_post(self):
     """
     Tests the method ``before_file_post()`` for correctly setting the `md5sum` property of a 
@@ -43,7 +34,7 @@ class TestConnection(unittest.TestCase):
     """
     payload = {
       self.conn.PROFILE_KEY: profiles.Profile.FILE_PROFILE_ID,
-      profiles.Profile.SUBMITTED_FILE_PROP_NAME: DATA_DIR+"/test_fq_40recs.fastq.gz"
+      profiles.Profile.SUBMITTED_FILE_PROP_NAME: "data/test_fq_40recs.fastq.gz"
     }
     res = self.conn.before_post_file(payload)
     self.assertEquals(res["md5sum"],"a3e7cb3df359d0642ab0edd33ea7e93e")
@@ -173,11 +164,6 @@ class TestConnection(unittest.TestCase):
     res = self.conn.make_search_url(search_args=query,limit=1) 
     query = "search/?assay_title=ChIP-seq&biosample_type=primary+cell&limit=1&organ_slims=blood&type=Experiment"
     self.assertEquals(res,os.path.join(self.conn.dcc_url,query))
-
-  def test_get(self):
-    res = self.conn.get('experiments/ENCSR502NRF/', frame='object')
-    self.assertEquals(res.get('uuid',""), "e44c59cc-f14a-4722-a9c5-2fe63c2b9533")
-
 
 if __name__ == "__main__":
   unittest.main()

--- a/encode_utils/tests/test_connection.py
+++ b/encode_utils/tests/test_connection.py
@@ -18,7 +18,11 @@ import encode_utils as eu
 from encode_utils import connection
 from encode_utils import profiles
 
-DATA_DIR = "data"
+#DATA_DIR = "data"
+DATA_DIR_NAME = "data"
+for root, dirs, files in os.walk('.'):
+      if DATA_DIR_NAME in dirs:
+        DATA_DIR = os.path.join(root, DATA_DIR_NAME)
 
 class TestConnection(unittest.TestCase):
   """Tests the ``encode_utils.connection.py`` module.
@@ -34,7 +38,7 @@ class TestConnection(unittest.TestCase):
     """
     payload = {
       self.conn.PROFILE_KEY: profiles.Profile.FILE_PROFILE_ID,
-      profiles.Profile.SUBMITTED_FILE_PROP_NAME: "data/test_fq_40recs.fastq.gz"
+      profiles.Profile.SUBMITTED_FILE_PROP_NAME: DATA_DIR+"/test_fq_40recs.fastq.gz"
     }
     res = self.conn.before_post_file(payload)
     self.assertEquals(res["md5sum"],"a3e7cb3df359d0642ab0edd33ea7e93e")

--- a/encode_utils/tests/test_utils.py
+++ b/encode_utils/tests/test_utils.py
@@ -31,7 +31,10 @@ import unittest
 
 from encode_utils import utils
 
-DATA_DIR = "data"
+DATA_DIR_NAME = "data"
+for root, dirs, files in os.walk('.'):
+      if DATA_DIR_NAME in dirs:
+        DATA_DIR = os.path.join(root, DATA_DIR_NAME)
 
 class TestUtils(unittest.TestCase):
   """

--- a/encode_utils/tests/test_utils.py
+++ b/encode_utils/tests/test_utils.py
@@ -31,10 +31,7 @@ import unittest
 
 from encode_utils import utils
 
-DATA_DIR_NAME = "data"
-for root, dirs, files in os.walk('.'):
-      if DATA_DIR_NAME in dirs:
-        DATA_DIR = os.path.join(root, DATA_DIR_NAME)
+DATA_DIR = "data"
 
 class TestUtils(unittest.TestCase):
   """


### PR DESCRIPTION
solves issues #1 and #3 

The test for "arbitrary" url isn't very clean.  I think it will error out if you give a bad URL (we bring them up and down all the time, so my test had to use test.encodedcc.org...) I am seeing about setting up a permanent test.demo.encodedcc.org alias for test.encodedcc.org but it's not trivial to get an SSH cert on it.