### PR TITLE
Remove one useless line; Fix setup bug.

### DIFF
--- a/encode_utils/MetaDataRegistration/eu_register.py
+++ b/encode_utils/MetaDataRegistration/eu_register.py
@@ -224,7 +224,6 @@ def create_payloads_from_json(profile_id, payloads):
     if isinstance(payloads, dict):
         payloads = [payloads]
     profile = eup.Profile(profile_id)
-    schema = profile.get_profile()
     for payload in payloads:
         payload[euc.Connection.PROFILE_KEY] = profile.profile_id
         yield payload

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
   install_requires = [
     "awscli",
     "google-api-python-client",
+    "jsonschema",
     "requests",
     "urllib3"],
   scripts = scripts,


### PR DESCRIPTION
* Found and removed one useless line from my previous PR #17 .

* Use eu_register from a new clean installation will trigger error:
    ```python
    ModuleNotFoundError: No module named 'jsonschema'
    ```
    from [utils.py line 15](https://github.com/StanfordBioinformatics/encode_utils/blob/master/encode_utils/utils.py#L15) for missing `jsonschema` package.

https://github.com/StanfordBioinformatics/encode_utils/blob/c5274b7fdbf29e8ba56086de01d167a7cd983930/encode_utils/utils.py#L15