### PR TITLE
Add boto3 to requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
   description = "Client and tools for ENCODE data submitters.",
   install_requires = [
     "awscli",
+    "boto3",
     "google-api-python-client",
     "inflection",
     "jsonschema",


### PR DESCRIPTION
Somehow boto3 is not installed when I install through pip, and I got this complain:

```bash
Traceback (most recent call last):
  File "/anaconda3/envs/wrangle/bin/eu_register.py", line 7, in <module>
    exec(compile(f.read(), __file__, 'exec'))
  File "/Users/yunhailuo/Github/encode_utils/encode_utils/MetaDataRegistration/eu_register.py", line 42, in <module>
    import encode_utils.utils as euu
  File "/Users/yunhailuo/Github/encode_utils/encode_utils/utils.py", line 22, in <module>
    import encode_utils.aws_storage
  File "/Users/yunhailuo/Github/encode_utils/encode_utils/aws_storage.py", line 12, in <module>
    import boto3
ModuleNotFoundError: No module named 'boto3'
```